### PR TITLE
Add .registration=TRUE to @useDynLib

### DIFF
--- a/350_package.Rmd
+++ b/350_package.Rmd
@@ -35,7 +35,7 @@ Imports: Rcpp
 * `NAMESPACE`ファイルに以下の記述を追加する
 
 ```
-useDynLib(myPackage)
+useDynLib(myPackage, .registration=TRUE)
 exportPattern("^[[:alpha:]]+")
 importFrom(Rcpp, sourceCpp)
 ```
@@ -127,7 +127,7 @@ Adding Rcpp to LinkingTo and Imports
 * Ignoring generated binary files.
 Next, include the following roxygen tags somewhere in your package:
 
-#' @useDynLib myPackage
+#' @useDynLib myPackage, .registration=TRUE
 #' @importFrom Rcpp sourceCpp
 NULL
 
@@ -138,7 +138,7 @@ Then run document()
 詳しくは次のセクションを参照ください。
 
 ```
-#' @useDynLib myPackage
+#' @useDynLib myPackage, .registration=TRUE
 #' @importFrom Rcpp sourceCpp
 NULL
 ```
@@ -153,7 +153,7 @@ roxygenタグからドキュメントのソースファイルを生成するに�
 例えば、下の記述をパッケージ内のRコードのどこかに記述してから `devtools::document()` を実行すると、
 
 ```
-#' @useDynLib myPackage
+#' @useDynLib myPackage, .registration=TRUE
 #' @importFrom Rcpp sourceCpp
 NULL
 ```


### PR DESCRIPTION
これあんまりちゃんと理解してないんですが、最近は`.registration=TRUE`を指定するようになっています。

* 公式アナウンス: https://stat.ethz.ch/pipermail/r-devel/2017-February/073755.html
* Rcpp: https://github.com/RcppCore/Rcpp/blob/a669a19e7ac51a072735279d92e1c6093a726743/R/Rcpp.package.skeleton.R#L105-L109
* usethis: https://github.com/r-lib/usethis/blob/d5ddeac9bbc8f79ce873febc6e2f430fd482f9f4/R/rcpp.R#L17